### PR TITLE
Resolve dark mode issue

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include LICENSE
+recursive-include share *
+recursive-include notebooks *
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for root, dirs, files in os.walk('share'):
 
 setup(
     name="voila-nbgallery",
-    version="0.0.5.dev0",
+    version="0.0.5",
     description="Voila templates for nbgallery project",
     long_description="Voila templates for nbgallery project",
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,14 @@ for root, dirs, files in os.walk('share'):
 
 setup(
     name="voila-nbgallery",
-    version="0.0.4",
+    version="0.0.5.dev0",
     description="Voila templates for nbgallery project",
     long_description="Voila templates for nbgallery project",
     long_description_content_type="text/markdown",
     url="https://github.com/nbgallery/voila-nbgallery",
     author='https://github.com/nbgallery',
     license='MIT',
+    packages=[],
     data_files=data_files,
     include_package_data=True,
     install_requires=[

--- a/share/jupyter/voila/templates/nbgallery-material/index.html.j2
+++ b/share/jupyter/voila/templates/nbgallery-material/index.html.j2
@@ -119,11 +119,11 @@
           <ul class="right">
             <li><a class="dropdown-trigger" href="#!" data-target="notebook-info">&nbsp;<i class="material-icons right" title="nbgallery info">info_outline</i></a></li>
             {% if resources.theme == 'dark' %}
-              <li><a href="?voila-theme=light"><i class="material-icons" title="Reload with light theme">brightness_5</i></a></li>
-              <li><a href="?voila-theme=dark&voila-template={{fallback_template}}"><i class="material-icons" title="Reload with plain template">note</i></a></li>
+              <li><a href="?theme=light"><i class="material-icons" title="Reload with light theme">brightness_5</i></a></li>
+              <li><a href="?theme=dark&voila-template={{fallback_template}}"><i class="material-icons" title="Reload with plain template">note</i></a></li>
             {% else %}
-              <li><a href="?voila-theme=dark"><i class="material-icons" title="Reload with dark theme">brightness_3</i></a></li>
-              <li><a href="?voila-theme=light&voila-template={{fallback_template}}"><i class="material-icons" title="Reload with plain template">note</i></a></li>
+              <li><a href="?theme=dark"><i class="material-icons" title="Reload with dark theme">brightness_3</i></a></li>
+              <li><a href="?theme=light&voila-template={{fallback_template}}"><i class="material-icons" title="Reload with plain template">note</i></a></li>
             {% endif %}
             <li><a href="#"><i class="material-icons" id="kernel-status-icon" title="kernel idle">radio_button_unchecked</i></a></li>
           </ul>


### PR DESCRIPTION
The dark/light mode button's URLs use `voila-theme` instead of `theme`; Voilà only recognizes `theme` to switch themes, so toggling fails. Changing links to theme=dark/light fixes the issue.

To test:
(recommendation: do this in a python virtual env)
`pip install -i https://test.pypi.org/simple/ voila-nbgallery`
`voila notebooks/nbgallery-metadata.ipynb --template=nbgallery-material`
Once the Voila app loads, click on the crescent moon icon ( ☽ ) to enable dark mode. Then click on the sun icon ( ❂) to enable light mode.